### PR TITLE
UpdateElements revamp plus security fix

### DIFF
--- a/NameSync.user.js
+++ b/NameSync.user.js
@@ -249,24 +249,24 @@ function setUp()
 		var optag = $("form[name='delform'] > .op", document)[0];
 		var id = $(".posteruid", optag)[0].innerHTML;
 		var nametag = $(".postername", optag)[0];
-		var filenamespan = $(".filesize a", optag)[0];
+		var filesizespan = $(".filesize", optag)[0];
 		var titlespan = $(".filetitle", optag)[0];
-		updatePost(id, nametag, filenamespan, titlespan);
+		updatePost(id, nametag, filesizespan, titlespan);
 
 		// Process replies separately because they differ
 		// slightly in a few class names.
 		$("form[name='delform'] > table tr > td[id]", document).each(function() {
 			var id = $(".posteruid", this)[0].innerHTML;
 			var nametag = $(".commentpostername", this)[0];
-			var filenamespan = $(".filesize a", this)[0];
+			var filesizespan = $(".filesize", this)[0];
 			var titlespan = $(".replytitle", this)[0];
-			updatePost(id, nametag, filenamespan, titlespan);
+			updatePost(id, nametag, filesizespan, titlespan);
 		});
 
 		storeCookie();
 	}
 
-	function updatePost(id, nametag, filenamespan, titlespan) {
+	function updatePost(id, nametag, filesizespan, titlespan) {
 		if(id == "(ID: Heaven)")
 			return;
 
@@ -300,7 +300,11 @@ function setUp()
 			titlespan.appendChild(guessbutton);
 		}
 
-		if(document.getElementById("onlineEnabled").checked && filenamespan != null) {
+		if(document.getElementById("onlineEnabled").checked && filesizespan != null) {
+			var filenamespan = $("span[title]", filesizespan)[0];
+			if(filenamespan == null) {
+				filenamespan = $("a[href]", filesizespan)[0];
+			}
 			var fullname = $(".fntrunc", filenamespan)[0];
 			if(fullname != null) {
 				filename = fullname.innerHTML;


### PR DESCRIPTION
The script was rarely working for me, so I decided to work on it. I looked at updateElements() and I think I see why: it goes through all of the spans together as an array and assumes things about their ordering. I think I had some 4chan X settings tweaked slightly, which made those assumptions mostly wrong.

The first commit here revamps the code so that it relies on the tag's class names, which is much more foolproof and readable. The first commit's changes are entirely in updateElements() and the new updatePost() functions. (Some of the OP post's tag's class names were slightly different, so updateElements parses that out and passes the post's tags onto updatePost(), which doesn't care whether it's given the OP post or a reply.)

The last commit makes sure that HTML entities are escaped before being displayed. Not doing this can cause a security vulnerability where someone could put HTML tags in their name. A script or iframe tag could be used to do evil things.

I see you put some note about not wanting others to work on it, but I think I separated my work out enough so it can probably either be meshed with your work or be copied from easily. My goal was to get something that worked completely for right now - I don't mind if you end up throwing these commits out and using something else that works.
