### PR TITLE
Put name of first queued reply, not selected one

### DIFF
--- a/NameSync.user.js
+++ b/NameSync.user.js
@@ -187,11 +187,12 @@ function setUp()
 			var cSubject;
 			var cFile = qr.contents().find('input[type="file"]').val();
 			
-			if (cFile == "" && $Jq("#selected[title]").length)
+			var queuedReplies = $Jq("#replies .preview[title]", qr);
+			if (queuedReplies.length)
 			{
-				cFile = $Jq("#selected[title]").attr("title");
+				cFile = queuedReplies.attr("title");
 			}
-			
+
 			if (getOption("Override Fields") == "true")
 			{
 				cName = getOption("Name");


### PR DESCRIPTION
Minor fix. If someone had several queued replies and hit submit, the name of the image of the currently selected reply (often the last one) would be sent instead of the name of the image of the reply being sent the soonest. If someone had a lot of images queued up to post, it could be a while before they finally post the image they sent the name of.

Also note that the first queued reply's name is preferred over what is in the in the upload box, because the filename in the upload box could correspond to one of the later replies, and 4chan X will be using the first queued reply anyway. This still correctly works for non-queued posts just as before.

Ideally the script could just hook into the Ajax call that 4chan X does to post, read the filename and everything from there, and not even have to try to deal with 4chan X's reply queue at all (this would also make adding support for other 4chan plugins easier than pie), but listening to events from a different plugin appears to be painful to do in a way that all browsers will support.
