### PR TITLE
Fix for new HTML change

### DIFF
--- a/NameSync.user.js
+++ b/NameSync.user.js
@@ -357,9 +357,9 @@ function setUp()
 		
 		$Jq("form[name='delform'] > div[class] > div[id] > .replyContainer > .reply", document).each(function() {
 			var id = $Jq(".posteruid", this)[0].innerHTML;
-			var nametag = $Jq(".name", this)[0];
-			var filetextspan = $Jq(".fileText", this)[0];
-			var subjectspan = $Jq(".subject", this)[0];
+			var nametag = $Jq(".desktop .name", this)[0];
+			var filetextspan = $Jq(".desktop .fileText", this)[0];
+			var subjectspan = $Jq(".desktop .subject", this)[0];
 			updatePost(id, nametag, filetextspan, subjectspan);
 		});
 		


### PR DESCRIPTION
Moot must have tweaked the HTML recently again. Now there's two tags with the nameBlock class (and name class, etc.) in every post, one for mobile and one for desktop. The script appeared to break because it only updated the invisible mobile nameBlock. This quick fixes that so it only affects the desktop nameBlock.

(There ought to be some simple Jquery way that would act on both blocks but I don't know enough Jquery and was just submitting a quick fix.)
