### PR TITLE
Efficiency improvements, bugfixes, jQuery, mobile CSS support

### DIFF
--- a/NameSync.user.js
+++ b/NameSync.user.js
@@ -38,7 +38,7 @@ function setUp()
 	var website = "http://milkytiptoe.github.com/Name-Sync/";
 	
 	// Initialized by loadNames()
-	var names;
+	var names = null;
 
 	var onlineNames = [];
 	var onlineFiles = [];
@@ -512,7 +512,7 @@ function setUp()
 			}
 			else
 			{
-				return null;
+				return "";
 			}
 		}
 		else
@@ -528,11 +528,11 @@ function setUp()
 
 	function loadNames()
 	{
-		names = JSON.parse(sessionStorage["names"]);
+		if(sessionStorage["names"] != null)
+			names = JSON.parse(sessionStorage["names"]);
 
-		if(names == null) {
+		if(names == null)
 			names = {};
-		}
 	}
 	
 	loadNames();


### PR DESCRIPTION
I've been using an old slow netbook for the last week or so due to my better laptop dying, and I've improved the script a bit to be more efficient. As threads got longer, my browser would have random pauses, and especially long pauses when new posts were loaded. I noticed each time a post was added, updateElements() updated every single post; if several posts were added at once, then updateElements() would update every post several times all at once. The first thing I changed was making it so that when posts are added, only that post is updated.

Next I redid part of updatePost() with more jQuery, making it support the mobile CSS at the same time (I'm not sure if any cellphone browsers can use userscripts yet, but the mobile CSS is also used when the browser window is resized to have a small width) and it now makes sure to only update the post if it doesn't already have the correct name and everything on it. It seems that minimizing changes to the DOM does wonders for efficiency. My netbook no longer noticeably pauses at all as it loads new posts or applies new data from your server. I've tested most of the code for a few days now, and it properly avoids getting confused by inlined posts and such.

I also noticed a big issue where if anyone's name or anything has a pipe symbol "|" in it, then bad things happen because the script tries to make a list by concatenating strings separated by pipes instead of just serializing the array into a JSON string. I fixed the cached names and IDs lists in these commits (and simplified it so instead of being two arrays, it was one array where the IDs were the keys and the names are the values), but the issue still exists when interpreting the response from the server. (I'll open another pull request or issue here soon with an example of how to fix the script side of it since that issue will need a server side fix too.)

A little minor change in here I put in changes it so it waits 3 seconds instead of 30 seconds before setting canPost back to true after hitting the submit button. If someone tries to upload an image, and gets a "file too large" or "image has already been posted" error, then 4chan X only forces a 3 second wait, and if the user tries to send another image before 30 seconds have passed, then their name+email+title don't get sent then.

I would sign in to MSN or Steam more often so if you wanted to chat about some of the code we could, but laptop issues are getting in the way there.
