### PR TITLE
Quick fix for people being able to fake tripcodes

### DIFF
--- a/NameSync.user.js
+++ b/NameSync.user.js
@@ -207,7 +207,7 @@ function setUp()
 				}
 				
 				cFile = escape(cFile);
-								
+					
 				$Jq.ajax({
 					headers: {"X-Requested-With":"Ajax"},
 					type: "POST",
@@ -298,7 +298,7 @@ function setUp()
 						{
 							var p = jQuery.parseJSON(jsonBlocks[i]);
 
-							onlineNames.push(unescape(p["n"]));
+							onlineNames.push(p["n"]);
 							onlineFiles.push(unescape(p["f"]));
 							onlineEmails.push(unescape(p["e"]));
 							onlineSubjects.push(unescape(p["s"]));


### PR DESCRIPTION
Started looking into some of the text encoding stuff I said I was going to help out with, and noticed a way for people to fake tripcodes by including "%23" in their name. This change patches out that for now, and requires no server changes. With this change, if anyone tries to fake a tripcode then you will see their fake trip code in their name field right after a "%23" as it should be. It might be a few more days before I'm able to help out with some of the other text encoding issues.
