### PR TITLE
Unhide 4chan X QR fields used by Name Sync but not 4chan.

### DIFF
--- a/src/NameSync.coffee
+++ b/src/NameSync.coffee
@@ -121,6 +121,10 @@ CSS =
     .section-name-sync {
       clear: both;
     }
+    /* Show sync fields in ccd0 4chan X */
+    #qr.sync-enabled .persona input {
+      display: inline-block !important;
+    }
     """
     if Set['Filter']
       css += """
@@ -392,6 +396,7 @@ Sync =
       return
 
     unless Set['Read-only Mode']
+      @setupQR()
       $.on d, 'QRPostSuccessful<% if (type === "crx") { %>_<% } %>', @requestSend
 
     $.on d, 'ThreadUpdate', @threadUpdate
@@ -429,6 +434,12 @@ Sync =
         $.event 'NamesSynced'
     if repeat and g.view is 'thread' and !Sync.disabled
       setTimeout Sync.sync, 30000, true
+  setupQR: ->
+    unless qr = $.id 'qr'
+      $.on d, 'QRDialogCreation', Sync.setupQR
+      return
+    $.addClass qr, 'sync-enabled'
+    $('input[data-name=email]', qr).placeholder = 'E-mail'
   requestSend: (e) ->
     postID   = e.detail.postID
     threadID = e.detail.threadID


### PR DESCRIPTION
This eliminates the need for ccd0 4chan X users to set up 4chan X
to show these fields.
